### PR TITLE
Filter on branchID if URL parameter is given

### DIFF
--- a/webservice/src/main/java/dk/dbc/laesekompas/suggester/webservice/SearchResource.java
+++ b/webservice/src/main/java/dk/dbc/laesekompas/suggester/webservice/SearchResource.java
@@ -108,6 +108,9 @@ public class SearchResource {
             put("defType", "dismax");
             put("qf", qf);
             put("bf", "log(loans)");
+            if (params.branchId != null) {
+                put("fq", "branch_id:\""+params.branchId+"\"");
+            }
             put(CommonParams.ROWS, Integer.toString(params.rows));
         }});
 
@@ -132,7 +135,8 @@ public class SearchResource {
                            @DefaultValue("") @QueryParam("field") String field,
                            @DefaultValue("false") @QueryParam("exact") boolean exact,
                            @DefaultValue("false") @QueryParam("merge_workid") boolean mergeWorkID,
-                           @DefaultValue("10") @QueryParam("rows") int rows) throws SolrServerException, IOException {
+                           @DefaultValue("10") @QueryParam("rows") int rows,
+                           @QueryParam("branch_id") String branchId) throws SolrServerException, IOException {
         // We require a query
         if (query == null) {
             return Response.status(400).build();
@@ -148,7 +152,7 @@ public class SearchResource {
 
         QueryResponse solrResponse = solr.query("search", solrSearchParams.apply(
                 // Asks for x3 rows when merging workID's, since a work can potentially have 3 manifestations
-                new SearchParams(query, field, exact, rows * (mergeWorkID ? 3 : 1))
+                new SearchParams(query, field, exact, rows * (mergeWorkID ? 3 : 1), branchId)
         ));
 
         int i = 0;
@@ -222,12 +226,14 @@ public class SearchResource {
         String field;
         boolean exact;
         int rows;
+        String branchId;
 
-        SearchParams(String query, String field, boolean exact, int rows) {
+        SearchParams(String query, String field, boolean exact, int rows, String branchId) {
             this.query = query;
             this.field = field;
             this.exact = exact;
             this.rows = rows;
+            this.branchId = branchId;
         }
 
         @Override

--- a/webservice/src/main/webapp/index.html
+++ b/webservice/src/main/webapp/index.html
@@ -38,6 +38,12 @@
     <p>
         <kbd>rows</kbd> specifies the maximum number of rows returned, defaults to 10.
     </p>
+    <p>
+        <kbd>branch_id</kbd> optional branch ID, filters so only results matching the query and exist on the given branch
+        are returned. As of now, only branches having materials on the bibliographic post that represents the work can
+        show up when filtering. This means that libraries having holdings of the same work, but not the exact books
+        that are indexed (representing the work) does not show up.
+    </p>
     <a href="https://github.com/DBCDK/suggester-laesekompas-webservice">Source code</a>
 </body>
 </html>

--- a/webservice/src/test/java/dk/dbc/laesekompas/suggester/webservice/SearchResourceIT.java
+++ b/webservice/src/test/java/dk/dbc/laesekompas/suggester/webservice/SearchResourceIT.java
@@ -61,7 +61,7 @@ public class SearchResourceIT {
     public void searchQuery() throws IOException, SolrServerException {
         solrClient.add("search", test1);
         solrClient.commit("search");
-        Response response = searchResource.search("john", "", false, false, 10);
+        Response response = searchResource.search("john", "", false, false, 10, null);
         List<SearchEntity> result = (List<SearchEntity>) response.getEntity();
         assertEquals(result.size(), 1);
     }

--- a/webservice/src/test/java/dk/dbc/laesekompas/suggester/webservice/SearchResourceTest.java
+++ b/webservice/src/test/java/dk/dbc/laesekompas/suggester/webservice/SearchResourceTest.java
@@ -54,6 +54,7 @@ public class SearchResourceTest {
         searchResource = new SearchResource();
 
         searchResource.searchSolrUrl = "http://invalid.invalid";
+        // Mocking basic test, shows results as given by SolR
         Mockito.when(test.getResults()).thenReturn(testDocs);
         Mockito.when(
                 solr.query(Mockito.eq("search"),
@@ -66,6 +67,7 @@ public class SearchResourceTest {
                         }})))
                 )
         ).thenReturn(test);
+        // Mocking test that rows parameter works
         Mockito.when(
                 solr.query(Mockito.eq("search"),
                         Mockito.argThat(new SolrParamsMatcher(new MapSolrParams(new HashMap<String, String>() {{
@@ -77,6 +79,7 @@ public class SearchResourceTest {
                         }})))
                 )
         ).thenReturn(test);
+        // Mocking test of querying author field
         Mockito.when(
                 solr.query(Mockito.eq("search"),
                         Mockito.argThat(new SolrParamsMatcher(new MapSolrParams(new HashMap<String, String>() {{
@@ -88,6 +91,7 @@ public class SearchResourceTest {
                         }})))
                 )
         ).thenReturn(test);
+        // Mocking test of querying author_exact field
         Mockito.when(
                 solr.query(Mockito.eq("search"),
                         Mockito.argThat(new SolrParamsMatcher(new MapSolrParams(new HashMap<String, String>() {{
@@ -99,6 +103,7 @@ public class SearchResourceTest {
                         }})))
                 )
         ).thenReturn(test);
+        // Mocking test querying title field
         Mockito.when(
                 solr.query(Mockito.eq("search"),
                         Mockito.argThat(new SolrParamsMatcher(new MapSolrParams(new HashMap<String, String>() {{
@@ -110,6 +115,7 @@ public class SearchResourceTest {
                         }})))
                 )
         ).thenReturn(test);
+        // Mocking test querying title_exact field
         Mockito.when(
                 solr.query(Mockito.eq("search"),
                         Mockito.argThat(new SolrParamsMatcher(new MapSolrParams(new HashMap<String, String>() {{
@@ -121,6 +127,7 @@ public class SearchResourceTest {
                         }})))
                 )
         ).thenReturn(test);
+        // Mocking testing merging on work IDs
         Mockito.when(testMergeWorkID.getResults()).thenReturn(testMergeWorkIDDocs);
         Mockito.when(
                 solr.query(Mockito.eq("search"),
@@ -133,6 +140,7 @@ public class SearchResourceTest {
                         }})))
                 )
         ).thenReturn(testMergeWorkID);
+        // Mocking test merging on work IDs when there are A-posts
         Mockito.when(testMergeWorkIDAPost.getResults()).thenReturn(testMergeWorkIDAPostDocs);
         Mockito.when(
                 solr.query(Mockito.eq("search"),
@@ -145,6 +153,7 @@ public class SearchResourceTest {
                         }})))
                 )
         ).thenReturn(testMergeWorkIDAPost);
+        // Mocking test that when merging on work IDs the correct number of rows show up
         Mockito.when(testMergeWorkIDNumRows.getResults()).thenReturn(testMergeWorkIDNumRowsDocs);
         Mockito.when(
                 solr.query(Mockito.eq("search"),
@@ -157,6 +166,7 @@ public class SearchResourceTest {
                         }})))
                 )
         ).thenReturn(testMergeWorkIDNumRows);
+        // Mocking test when merging on work IDs when SolR cannot return enough
         Mockito.when(testMergeWorkIDFewRows.getResults()).thenReturn(testMergeWorkIDFewRowsDocs);
         Mockito.when(
                 solr.query(Mockito.eq("search"),
@@ -169,13 +179,27 @@ public class SearchResourceTest {
                         }})))
                 )
         ).thenReturn(testMergeWorkIDFewRows);
+        // Mocking branch_id filter test
+        Mockito.when(test.getResults()).thenReturn(testDocs);
+        Mockito.when(
+                solr.query(Mockito.eq("search"),
+                        Mockito.argThat(new SolrParamsMatcher(new MapSolrParams(new HashMap<String, String>() {{
+                            put(CommonParams.Q, "filter on branch");
+                            put("defType", "dismax");
+                            put("qf", SearchResource.SOLR_FULL_TEXT_QUERY);
+                            put("fq", "branch_id:\"b1\"");
+                            put("bf", "log(loans)");
+                            put(CommonParams.ROWS, "10");
+                        }})))
+                )
+        ).thenReturn(test);
         searchResource.solr = solr;
         searchResource.maxNumberSuggestions = MAX_SUGGESTIONS;
     }
 
     @Test
     public void getSearchReturnsResults() throws IOException, SolrServerException {
-        Response response = searchResource.search("john", "", false, false, 10);
+        Response response = searchResource.search("john", "", false, false, 10, null);
         List<SearchEntity> result = (List<SearchEntity>) response.getEntity();
 
         List<SearchEntity> expectedList = Arrays.asList(testDocSearchEntity1);
@@ -185,36 +209,36 @@ public class SearchResourceTest {
     @Test
     public void fieldQueryParamAuthorProperSolRParam() throws IOException, SolrServerException {
         // If proper SolrParams are not generated, result will not be mocked, and search throws exception
-        searchResource.search("author_field", "author", false, false, 10);
+        searchResource.search("author_field", "author", false, false, 10, null);
     }
 
     @Test
     public void fieldQueryParamAuthorExactProperSolRParam() throws IOException, SolrServerException {
         // If proper SolrParams are not generated, result will not be mocked, and search throws exception
-        searchResource.search("author_field_exact", "author", true, false, 10);
+        searchResource.search("author_field_exact", "author", true, false, 10, null);
     }
 
     @Test
     public void fieldQueryParamTitleProperSolRParam() throws IOException, SolrServerException {
         // If proper SolrParams are not generated, result will not be mocked, and search throws exception
-        searchResource.search("title_field", "title", false, false, 10);
+        searchResource.search("title_field", "title", false, false, 10, null);
     }
 
     @Test
     public void fieldQueryParamTitleExactProperSolRParam() throws IOException, SolrServerException {
         // If proper SolrParams are not generated, result will not be mocked, and search throws exception
-        searchResource.search("title_field_exact", "title", true, false, 10);
+        searchResource.search("title_field_exact", "title", true, false, 10, null);
     }
 
     @Test
     public void rowsProperSolRParam() throws IOException, SolrServerException {
         // If proper SolrParams are not generated, result will not be mocked, and search throws exception
-        searchResource.search("rows", "", false, false, 20);
+        searchResource.search("rows", "", false, false, 20, null);
     }
 
     @Test
     public void mergeWorkIDParam() throws IOException, SolrServerException {
-        Response response = searchResource.search("merge", "", false, true, 10);
+        Response response = searchResource.search("merge", "", false, true, 10, null);
         List<SearchEntity> result = (List<SearchEntity>) response.getEntity();
 
         List<SearchEntity> expectedList = Arrays.asList(testMergeWorkID1, testMergeWorkID2, testMergeWorkID3);
@@ -224,7 +248,7 @@ public class SearchResourceTest {
     @Test
     public void mergeReturnAtMostRequestedNumRows() throws IOException, SolrServerException {
         int rows = 2;
-        Response response = searchResource.search("merge #rows", "", false, true, rows);
+        Response response = searchResource.search("merge #rows", "", false, true, rows, null);
         List<SearchEntity> result = (List<SearchEntity>) response.getEntity();
 
         assertEquals(result.size(), rows);
@@ -233,7 +257,7 @@ public class SearchResourceTest {
     @Test
     public void mergeDontFailOnFewResults() throws IOException, SolrServerException {
         int rows = 5;
-        Response response = searchResource.search("merge #rows few", "", false, true, rows);
+        Response response = searchResource.search("merge #rows few", "", false, true, rows, null);
         List<SearchEntity> result = (List<SearchEntity>) response.getEntity();
 
         // Test that the test is essentially testing what it is supposed to
@@ -243,10 +267,19 @@ public class SearchResourceTest {
 
     @Test
     public void mergeWorkIdPrioritizeAPost() throws IOException, SolrServerException {
-        Response response = searchResource.search("merge a-post", "", false, true, 10);
+        Response response = searchResource.search("merge a-post", "", false, true, 10, null);
         List<SearchEntity> result = (List<SearchEntity>) response.getEntity();
 
         List<SearchEntity> expectedList = Arrays.asList(testMergeWorkIDAPost1, testMergeWorkIDAPost2);
+        assertThat(result, IsIterableContainingInOrder.contains(expectedList.toArray()));
+    }
+
+    @Test
+    public void filterBranchId() throws IOException, SolrServerException {
+        Response response = searchResource.search("filter on branch", "", false, false, 10, "b1");
+        List<SearchEntity> result = (List<SearchEntity>) response.getEntity();
+
+        List<SearchEntity> expectedList = Arrays.asList(testDocSearchEntity1);
         assertThat(result, IsIterableContainingInOrder.contains(expectedList.toArray()));
     }
 


### PR DESCRIPTION
In order to filter on branches when searching, a SolR index field has been added to the search collection. In order for the webservice to filter, it simply needs to query the SolR with the branchID as a filter (SolR `&fq=branch_id:"agencyId/bibId"`).

The branch id is given as an optional URL parameter.